### PR TITLE
Check if config file exists

### DIFF
--- a/temp.sh
+++ b/temp.sh
@@ -385,6 +385,11 @@ main() {
 	check_already_running
 	check_driver
 
+	if [ ! -f "$config_file" ]; then
+        >&2 echo "Config file not found."
+        exit 1
+	fi
+	
 	source "$config_file"
 	clen="$(( ${#fcurve[@]} - 1 ))"
 


### PR DESCRIPTION
When using nfancurve there are many errors when you do not have a config. Now the script checks for a config before doing anything.