### PR TITLE
Create systemd example to run nfancurve on boot

### DIFF
--- a/nfancurve.service
+++ b/nfancurve.service
@@ -1,0 +1,11 @@
+# /etc/systemd/user/nfancurve.service
+
+[Unit]
+Description=Nfancurve service
+PartOf=graphical-session.target
+
+[Service]
+ExecStart=/bin/sh NFANCURVE_PATH/temp.sh
+
+[Install]
+WantedBy=xsession.target


### PR DESCRIPTION
Replace `NFANCURVE_PATH` with the `nfancurve` path.
Move or copy the `nfancurve.service` file to `/etc/systemd/user/nfancurve.service` and enable + start the service with:
- `systemctl --user daemon-reload`
- `systemctl --user start nfancurve.service`
- `systemctl --user enable nfancurve.service`