### PR TITLE
Fix num_fans and num_gpus value extraction

### DIFF
--- a/temp.sh
+++ b/temp.sh
@@ -220,7 +220,7 @@ arr="$fcurve"; arr_size; fcurve_len="$((arr_len-1))"
 arr="$fcurve2"; arr_size; fcurve_len2="$((arr_len-1))"
 
 # Get the system's GPU configuration
-num_fans=$(get_query "fans"); num_fans="${num_fans%* Fan on*}"
+num_fans=$(get_query "fans"); num_fans="${num_fans%* Fans on*}"
 if [ -z "$num_fans" ]; then
 	prf "No Fans detected"; exit 1
 elif [ "${#num_fans}" -gt "2" ]; then
@@ -228,7 +228,7 @@ elif [ "${#num_fans}" -gt "2" ]; then
 else
 	prf "Number of Fans detected: $num_fans"
 fi
-num_gpus=$(get_query "gpus"); num_gpus="${num_gpus%* GPU on*}"
+num_gpus=$(get_query "gpus"); num_gpus="${num_gpus%* GPUs on*}"
 if [ -z "$num_gpus" ]; then
 	prf "No GPUs detected"; exit 1
 elif [ "${#num_gpus}" -gt "2" ]; then


### PR DESCRIPTION
`nvidia-settings` returns the following queries for me:
```
$ nvidia-settings -q fans
2 Fans on workspace:1

    [0] workspace:1[fan:0] (Fan 0)

      Has the following name:
        FAN-0

    [1] workspace:1[fan:1] (Fan 1)

      Has the following name:
        FAN-1
```
```
$ nvidia-settings -q gpus
2 GPUs on workspace:1

    [0] workspace:1[gpu:0] (GeForce GTX 1080 Ti)

      Has the following names:
        GPU-0
        GPU-e915a2f6-a06f-ba99-b10b-9933ab8cd26d

    [1] workspace:1[gpu:1] (GeForce RTX 2080 Ti)

      Has the following names:
        GPU-1
        GPU-66a1cde9-efde-b533-2750-5ce8f1afcafc
```
The extra 's' there prevented the code from extracting the correct values for me.