### PR TITLE
Fixes the provided systemd unit file to use graphical-session.target.

### DIFF
--- a/nfancurve.service
+++ b/nfancurve.service
@@ -1,11 +1,10 @@
-# /etc/systemd/user/nfancurve.service
-
 [Unit]
 Description=Nfancurve service
-PartOf=graphical-session.target
+After=graphical-session.target
+Requires=graphical-session.target
 
 [Service]
-ExecStart=/bin/sh NFANCURVE_PATH/temp.sh
+ExecStart=/bin/sh /usr/bin/nfancurve -c /etc/nfancurve.conf
 
 [Install]
-WantedBy=xsession.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
The old service file used a WantedBy xsession.target which is not a preexisting target.
graphical-session.target should be correctly used by the desktop environment.