### PR TITLE
temp.sh: Initialize iterator correctly so fans step down

### DIFF
--- a/temp.sh
+++ b/temp.sh
@@ -142,6 +142,7 @@ loop_cmds() {
 			if [ "$new_spd" -ne "$cur_spd" ]; then
 				cur_spd="$new_spd"
 				set_speed
+				i=0
 				tmp="$old_s"; old_s=""
 				for elem in $tmp; do
 					if [ "$i" -ne "$fan" ]; then


### PR DESCRIPTION
The iterator was being set to '1' elsewhere in the script and
the current speed was not saved correctly so when temps lowered the
fan speed was not decreased.