### PR TITLE
nfancurve.service: Send SIGINT on stop so fan profile is reset

### DIFF
--- a/nfancurve.service
+++ b/nfancurve.service
@@ -5,6 +5,7 @@ Requires=graphical-session.target
 
 [Service]
 ExecStart=/bin/sh /usr/bin/nfancurve -c /etc/nfancurve.conf
+KillSignal=SIGINT
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
The shell script expects to catch a CTRL-C (SIGINT) so that it will
turn off the custom fan speed setting and let the VBIOS resume control.
The default systemd signal is SIGTERM so the custom fan profile never
gets turned off on a systemd stop command.