### PR TITLE
Fix startup with low speeds

### DIFF
--- a/temp.sh
+++ b/temp.sh
@@ -3,8 +3,8 @@
 prf() { printf %s\\n "$*" ; }
 z=$0; display=""; CDPATH=""; fname=""; num_gpus="0"; num_fans="0"; debug="0"
 max_t="0"; max_t2="0"; mnt="0"; mxt="0"; ot="0"; tdiff="0"; cur_t="0"
-new_spd="0"; cur_spd="0"; old_t="200"; check_diff1="0"; check_diff2="0"
-fcurve_len="0"; fcurve_len2="0"; num_gpus_loop="0"; num_fans_loop="0"; old_s="0"
+new_spd="0"; cur_spd="100"; old_t="200"; check_diff1="0"; check_diff2="0"
+fcurve_len="0"; fcurve_len2="0"; num_gpus_loop="0"; num_fans_loop="0"; old_s="100"
 otl="-1"; sleep_override=""; gpu_cmd="nvidia-settings"
 
 usage="Usage: $(basename "$0") [OPTION]...


### PR DESCRIPTION
The Nvidia driver on my machine uses a speed of 32% by default when manual fan control is activated. This script on the other hand assumed that the default was 0%. As a result, it did not try to change the speed and the fan kept running at 32% even though temperatures were low enough to switch it off. By setting the initial speed to 100% instead, the script is guaranteed to adjust the speed downwards.