### PR TITLE
Add fail-safe in case of nvidia-settings segfault

### DIFF
--- a/temp.sh
+++ b/temp.sh
@@ -113,6 +113,9 @@ re_elem() {
 }
 loop_cmds() {
 	get_temp
+	case ${cur_t#-} in
+		''|*[!0-9]*) cur_t=$ot ;;
+	esac
 	if [ "$cur_t" -ne "$ot" ]; then
 		# Calculate difference and make sure it's positive
 		if [ "$cur_t" -le "$ot" ]; then


### PR DESCRIPTION
Now and then, nvidia-settings throws a segfault for whatever reason on my machine, which causes the script to set `cur_t` to something that is not a number, eventually freezing the whole OS.

```
kernel: [ 1652.744323] nvidia-settings[10112]: segfault at 7faf6e5f97 ip 00007faf6dffcee0 sp 00007ffcc781d520 error 4 in libgtk-3.so.0.2404.16[7faf6dee3000+36f000]
kernel: [ 1652.744329] Code: 84 a5 03 00 00 48 8b 31 48 8b 38 48 89 54 24 28 e8 95 f0 ee ff 48 8b 54 24 28 85 c0 79 ac 8b 4c 24 48 0f 1f 84 00 00 00 00 00 <f3> 0f 6f 0a 89 4c 24 08 0f 29 4c 24 50 48 8b 42 10 48 89 44 24 60
gpufancurve.desktop[2103]: Segmentation fault (core dumped)
gpufancurve.desktop[2103]: /home/suburbski/nfancurve/temp.sh: 116: [: Illegal number: 
```

This fix adds a [check](https://stackoverflow.com/a/3951175) which prevents the OS freeze in my case and generally other  problems caused by temperature reading faults by setting `cur_t` to `ot` in case the former is not a number.