### PR TITLE
Set en_US locale when running systemd service

### DIFF
--- a/nfancurve.service
+++ b/nfancurve.service
@@ -5,6 +5,7 @@ After=default.target
 [Service]
 ExecStart=/bin/sh /usr/bin/nfancurve -c /etc/nfancurve.conf
 KillSignal=SIGINT
+Environment=LC_ALL=en_US.UTF-8
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Before this change, nvidia-settings reported the following warning every time nfancurve invoked it:

    Jun 21 19:08:22 arch nvidia-settings[37916]: Locale not supported by C library.
                                                         Using the fallback 'C' locale.

which polluted journalctl for no good reason. Perhaps this is related to the fact that systemd services start with empty environment. Setting some specific locale, for example en_US.UTF-8, prevents this warning from being reported.