### PR TITLE
BETA - New features "Equation-Mode" and "Smooth-Decrease" 

### DIFF
--- a/config
+++ b/config
@@ -3,11 +3,11 @@
 #  first speed in fcurve is (default of 25%)
 # min_t2 is only used with the second fan speed and temperature arrays, so
 #  there is no need to change it unless you're using the second curve
-min_t="0"
-min_t2="0"
+min_t="25"
+min_t2="25"
 
 # How many seconds the script should wait until checking for a change in temps
-sleep_time="3"
+sleep_time="7"
 
 # By default it's set up so that when the temp is less than or equal to 35
 #  degrees, the fan speed will be set to 25%. Next, if the temp is between 36
@@ -22,12 +22,12 @@ tcurve="35 45 55 65 75" # temperatures
 
 
 #defines if equation-mode is being used. If equation_mode is on, the script will calculate the correct fan speed from the defined equation instead of using fcurve and tcurve, thus achieving a smoother fan-curve
-equation_mode="1"
+equation_mode="0"
 
 # the equation for the primary fan (used if equation_mode is 1)if equation_mode is 1 the script will set the fan speed to the corresponding value of the equation in quotation marks ($cur_t represents the current temperature)
 #example:
 #equation1='9.6533531762886*1.0305283856818^$cur_t'
-equation1='18.3138081180607*1.0160111895552^$cur_t'
+equation1=
 
 # if equation_mode is 1, this is the temperature at which 100% fan speed will be set
 equation_max="90"
@@ -39,7 +39,7 @@ equation_max="90"
 force_check="0"
 
 #if this value is one, if the temperature is decreasing the script will lower the fan speed smoothly 1% at every temperature check, instead of directly switching to the corresponding value in fcurve or the equation
-smooth_decrease="1"
+smooth_decrease="0"
 
 # defines the minium setpoint the fan-speed will decrease to 
 smooth_decrease_setpoint="30"
@@ -52,7 +52,7 @@ tcurve2="35 45 55 65 75"
 # the equation for the secondary fan (used if equation_mode is 1)
 #example:
 #equation2='9.6533531762886*1.0305283856818^$cur_t'
-equation2='18.3138081180607*1.0160111895552^$cur_t'
+equation2=
 
 # First number in array is fan 0, second number is fan 1, etc. If the number
 #  is 1, that indicates that the script should use the first curve for that

--- a/config
+++ b/config
@@ -3,11 +3,11 @@
 #  first speed in fcurve is (default of 25%)
 # min_t2 is only used with the second fan speed and temperature arrays, so
 #  there is no need to change it unless you're using the second curve
-min_t="25"
-min_t2="25"
+min_t="0"
+min_t2="0"
 
 # How many seconds the script should wait until checking for a change in temps
-sleep_time="7"
+sleep_time="3"
 
 # By default it's set up so that when the temp is less than or equal to 35
 #  degrees, the fan speed will be set to 25%. Next, if the temp is between 36
@@ -21,17 +21,16 @@ tcurve="35 45 55 65 75" # temperatures
 
 
 
-#defines if equation-mode is being used
-equationMode=0
+#defines if equation-mode is being used. If equation_mode is on, the script will calculate the correct fan speed from the defined equation instead of using fcurve and tcurve, thus achieving a smoother fan-curve
+equation_mode="1"
 
-# if equationMode is 1 the script will set the fan speed to the corresponding value of the equation in quotation marks ($cur_t represents the current temperature)
+# the equation for the primary fan (used if equation_mode is 1)if equation_mode is 1 the script will set the fan speed to the corresponding value of the equation in quotation marks ($cur_t represents the current temperature)
 #example:
-#equation='9.6533531762886*1.0305283856818^$cur_t'
-equation=
+#equation1='9.6533531762886*1.0305283856818^$cur_t'
+equation1='18.3138081180607*1.0160111895552^$cur_t'
 
-# if using the equation, this is the temperature at which 100% fan speed will be set
-equationMax="85"
-
+# if equation_mode is 1, this is the temperature at which 100% fan speed will be set
+equation_max="90"
 
 # This value is used to determine the temperature difference needed to get
 #  the script to check for a new speed to apply. The default of this value
@@ -40,15 +39,20 @@ equationMax="85"
 force_check="0"
 
 #if this value is one, if the temperature is decreasing the script will lower the fan speed smoothly 1% at every temperature check, instead of directly switching to the corresponding value in fcurve or the equation
-smoothDecrease="1"
+smooth_decrease="1"
 
 # defines the minium setpoint the fan-speed will decrease to 
-smoothDecreaseSetPoint="25"
+smooth_decrease_setpoint="30"
 
 # These two arrays are for GPU's that have a secondary fan that you may wish
 #  to control seperately, especially if it is water-cooled.
 fcurve2="15 30 45 60 75"
 tcurve2="35 45 55 65 75"
+
+# the equation for the secondary fan (used if equation_mode is 1)
+#example:
+#equation2='9.6533531762886*1.0305283856818^$cur_t'
+equation2='18.3138081180607*1.0160111895552^$cur_t'
 
 # First number in array is fan 0, second number is fan 1, etc. If the number
 #  is 1, that indicates that the script should use the first curve for that

--- a/config
+++ b/config
@@ -19,11 +19,29 @@ sleep_time="7"
 fcurve="25 40 55 70 85" # fan speeds
 tcurve="35 45 55 65 75" # temperatures
 
+# defines if equation-mode is being used
+equationMode=1
+
+# if equationMode is 1 the script will set the fan speeds to the corresponding 
+#  value of the equation in quotation marks 
+#  ($cur_t represents the current temperature)
+#  Example:
+#  equation='18.3138081180607*1.0160111895552^$cur_t'
+equation=
+
+# if using the equation, this is the temperature at which 100% fan speed will be set
+equationMax="90"
+
 # This value is used to determine the temperature difference needed to get
 #  the script to check for a new speed to apply. The default of this value
 #  is zero, which means the script will automatically calculate a value
 #  based on the temperature curves supplied below
 force_check="0"
+
+# if this value is one, if the temperature is decreasing the script will lower 
+#  the fan speed smoothly 1% at every temperature check, instead of directly 
+#  switching to the corresponding value in fcurve or the equation
+smoothDecrease="1"
 
 # These two arrays are for GPU's that have a secondary fan that you may wish
 #  to control seperately, especially if it is water-cooled.

--- a/config
+++ b/config
@@ -19,18 +19,19 @@ sleep_time="7"
 fcurve="25 40 55 70 85" # fan speeds
 tcurve="35 45 55 65 75" # temperatures
 
-# defines if equation-mode is being used
-equationMode=1
 
-# if equationMode is 1 the script will set the fan speeds to the corresponding 
-#  value of the equation in quotation marks 
-#  ($cur_t represents the current temperature)
-#  Example:
-#  equation='18.3138081180607*1.0160111895552^$cur_t'
+
+#defines if equation-mode is being used
+equationMode=0
+
+# if equationMode is 1 the script will set the fan speed to the corresponding value of the equation in quotation marks ($cur_t represents the current temperature)
+#example:
+#equation='9.6533531762886*1.0305283856818^$cur_t'
 equation=
 
 # if using the equation, this is the temperature at which 100% fan speed will be set
-equationMax="90"
+equationMax="85"
+
 
 # This value is used to determine the temperature difference needed to get
 #  the script to check for a new speed to apply. The default of this value
@@ -38,10 +39,11 @@ equationMax="90"
 #  based on the temperature curves supplied below
 force_check="0"
 
-# if this value is one, if the temperature is decreasing the script will lower 
-#  the fan speed smoothly 1% at every temperature check, instead of directly 
-#  switching to the corresponding value in fcurve or the equation
+#if this value is one, if the temperature is decreasing the script will lower the fan speed smoothly 1% at every temperature check, instead of directly switching to the corresponding value in fcurve or the equation
 smoothDecrease="1"
+
+# defines the minium setpoint the fan-speed will decrease to 
+smoothDecreaseSetPoint="25"
 
 # These two arrays are for GPU's that have a secondary fan that you may wish
 #  to control seperately, especially if it is water-cooled.


### PR DESCRIPTION
I always found it a bit annoying that you could hear the GPU changing fan speeds, because the values for the fan curve where to far apart. With these two features, which can be enabled optionaly, the fan speeds change very smoothly without the need to fill the fan curve with lots of values.

 With "Equation-Mode" you can input an equation instead of manually defining values for the fan curve. To get an equation, you could for example use [this interactive tool](https://www.geogebra.org/m/Fdg996u8) to get an exponential equation (Just put in a couple points and a fitting equation will be generated). The equation might look like this:`9.6533531762886*1.0305283856818^$cur_t` (where "$cur_t" represents the current GPU temperature). This way, the fan speed is smoothly calculated for every temperature change.

The other feature, "Smooth-Decrease" detects if the fan speed is currently decreasing. If it is, it lowers the fan speed by 1% every time the script checks the temperature until it reaches a defined value. If the fan speed starts rising, the fan curve / equation takes over again.