### PR TITLE
adds bash reference in hash bang line

### DIFF
--- a/temp.sh
+++ b/temp.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #!/bin/sh
 
 prf() { printf %s\\n "$*" ; }


### PR DESCRIPTION
This change resolves issue #47 by referencing bash in temp.sh on Ubuntu based systems. 